### PR TITLE
add method for sending grades to clever

### DIFF
--- a/lib/clever.rb
+++ b/lib/clever.rb
@@ -25,6 +25,7 @@ module Clever
   COURSES_ENDPOINT  = '/v2.0/courses'
   SECTIONS_ENDPOINT = '/v2.0/sections'
   TEACHERS_ENDPOINT = '/v2.0/teachers'
+  GRADES_ENDPOINT   = 'https://grades-api.beta.clever.com/v1/grade'
 
   class DistrictNotFound < StandardError; end
   class ConnectionError < StandardError; end

--- a/lib/clever/client.rb
+++ b/lib/clever/client.rb
@@ -84,6 +84,12 @@ module Clever
       enrollments
     end
 
+    def send_grade(request_body)
+      authenticate
+
+      @connection.execute(GRADES_ENDPOINT, :post, nil, request_body)
+    end
+
     private
 
     def parse_enrollments(classroom_uids, sections)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -82,6 +82,38 @@ RSpec.describe Clever::Client do
     end
   end
 
+  describe 'send_grade' do
+    before do
+      client.connection.expects(:execute).with(Clever::TOKENS_ENDPOINT).returns(tokens_response)
+      client.connection.expects(:set_token).with(app_token)
+      client.connection.expects(:execute)
+        .with(Clever::GRADES_ENDPOINT, :post, nil, request_body)
+        .returns(mock_response)
+    end
+    let(:request_body) do
+      { userID: 'userId', assignmentId: 'assignmentId', scoreGiven: 1, scoreMaximum: 100 }
+    end
+    let(:response) { client.send_grade(request_body) }
+
+    context 'unsuccessful response' do
+      let(:mock_response) { Clever::Response.new(stub(body: nil, status: 401)) }
+
+      it 'returns a failed response' do
+        expect(response.success?).to eq(false)
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'successful response' do
+      let(:mock_response) { Clever::Response.new(stub(body: nil, status: 200)) }
+
+      it 'returns a response with the body mapped' do
+        expect(response.success?).to eq(true)
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
   describe 'district data requests' do
     before do
       client.connection.expects(:execute).with(Clever::TOKENS_ENDPOINT).returns(tokens_response)


### PR DESCRIPTION
Adds method to send grade to clever passback by sending a post request to `https://grades-api.beta.clever.com/v1/grade` with `userID`, `assignmentId`, `scoreGiven`, and `scoreMaximum`. 