### PR TITLE
add method to check if a district exists

### DIFF
--- a/lib/clever.rb
+++ b/lib/clever.rb
@@ -29,6 +29,7 @@ module Clever
   TEACHERS_ENDPOINT = '/v2.0/teachers'
   EVENTS_ENDPOINT   = '/v1.2/events'
   TERMS_ENDPOINT    = '/v2.0/terms'
+  DISTRICT_ENDPOINT = '/v2.1/districts'
   GRADES_ENDPOINT   = 'https://grades-api.beta.clever.com/v1/grade'
 
   class DistrictNotFound < StandardError; end

--- a/lib/clever/client.rb
+++ b/lib/clever/client.rb
@@ -111,6 +111,16 @@ module Clever
       @connection.execute(GRADES_ENDPOINT, :post, nil, request_body)
     end
 
+    def district_exists?(uid)
+      begin
+        authenticate
+      rescue Clever::DistrictNotFound
+        return false
+      end
+
+      !!@connection.execute(DISTRICT_ENDPOINT, :get, id: uid)
+    end
+
     private
 
     def parse_enrollments(classroom_uids, sections)


### PR DESCRIPTION
For [PLAT-2645](https://teachtci2.atlassian.net/browse/PLAT-2645), we need to check if the user gave us the correct uid by hitting the districts endpoint. This pr adds that method.