### PR TITLE
[PLAT-14275] Clever raise error to enter sidekiq retry

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    clever (3.2.10)
+    clever (3.2.11)
       faraday
       faraday_middleware
 

--- a/lib/clever/connection.rb
+++ b/lib/clever/connection.rb
@@ -22,7 +22,7 @@ module Clever
           'response.http_status' => response.status,
           'response.raw_body' => response.raw_body
         )
-        raise GatewayTimeoutError if response.status == 504
+        raise GatewayTimeoutError if response.timed_out?
       end
 
       response

--- a/lib/clever/connection.rb
+++ b/lib/clever/connection.rb
@@ -22,6 +22,7 @@ module Clever
           'response.http_status' => response.status,
           'response.raw_body' => response.raw_body
         )
+        raise if response.status == 504
       end
 
       response

--- a/lib/clever/connection.rb
+++ b/lib/clever/connection.rb
@@ -22,7 +22,7 @@ module Clever
           'response.http_status' => response.status,
           'response.raw_body' => response.raw_body
         )
-        raise if response.status == 504
+        raise GatewayTimeoutError if response.status == 504
       end
 
       response
@@ -69,5 +69,7 @@ module Clever
 
       @client.sentry_client.capture_message('Exception in Clever::Connection', **{ extra: payload })
     end
+
+    class GatewayTimeoutError < StandardError; end
   end
 end

--- a/lib/clever/response.rb
+++ b/lib/clever/response.rb
@@ -23,6 +23,10 @@ module Clever
       @status == 200
     end
 
+    def timed_out?
+      @status == 504
+    end
+
     private
 
     def uri(kind)

--- a/lib/clever/version.rb
+++ b/lib/clever/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Clever
-  VERSION = '3.2.10'
+  VERSION = '3.2.11'
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -99,13 +99,15 @@ RSpec.describe Clever::Connection do
       end
 
       context '504 response' do
+        subject { connection.execute('/teachers', :get, limit: Clever::PAGE_LIMIT) }
+
         let(:status) { 504 }
-        let(:body) { 'Bad Gateway' }
+        let(:body) { 'Gateway Timeout' }
 
         before { connection.stubs(:raw_request).returns(mock_response) }
 
         it 'raises an error' do
-          expect { connection.execute('/teachers', :get, limit: Clever::PAGE_LIMIT) }.to raise_error
+          expect { subject }.to raise_error(Clever::Connection::GatewayTimeoutError)
         end
 
         context 'with a sentry_client configured' do
@@ -114,7 +116,7 @@ RSpec.describe Clever::Connection do
           it 'logs to sentry and raises' do
             sentry_client.expects(:capture_message)
 
-            expect { connection.execute('/teachers', :get, limit: Clever::PAGE_LIMIT) }.to raise_error
+            expect { subject }.to raise_error(Clever::Connection::GatewayTimeoutError)
           end
         end
       end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -97,6 +97,27 @@ RSpec.describe Clever::Connection do
           end
         end
       end
+
+      context '504 response' do
+        let(:status) { 504 }
+        let(:body) { 'Bad Gateway' }
+
+        before { connection.stubs(:raw_request).returns(mock_response) }
+
+        it 'raises an error' do
+          expect { connection.execute('/teachers', :get, limit: Clever::PAGE_LIMIT) }.to raise_error
+        end
+
+        context 'with a sentry_client configured' do
+          let(:sentry_client) { stub(capture_message: stub) }
+
+          it 'logs to sentry and raises' do
+            sentry_client.expects(:capture_message)
+
+            expect { connection.execute('/teachers', :get, limit: Clever::PAGE_LIMIT) }.to raise_error
+          end
+        end
+      end
     end
 
     describe '#log' do


### PR DESCRIPTION
PLAT-14275
This PR explicitly raises an error if the response status is a 504, which will force the sidekiq job into retries.